### PR TITLE
Add LTI consumer key and secret to config template

### DIFF
--- a/settings.py.template
+++ b/settings.py.template
@@ -1,6 +1,8 @@
 # API url and LTI key/secret
 BASE_URL = ''
 API_URL = ''
+LTI_CONSUMER_KEY = ''
+LTI_CONSUMER_SECRET = ''
 
 # generate a secret key with os.urandom(24)
 secret_key = ''
@@ -32,8 +34,8 @@ DATABASE_URIS = {
 
 PYLTI_CONFIG = {
     'consumers': {
-        "key": {
-            "secret": "secret"
+        LTI_CONSUMER_KEY: {
+            "secret": LTI_CONSUMER_SECRET
         }
     },
     'roles': {
@@ -41,5 +43,3 @@ PYLTI_CONFIG = {
         'student': ['Student', 'urn:lti:instrole:ims/lis/Student']
     }
 }
-
-

--- a/settings.py.template
+++ b/settings.py.template
@@ -2,7 +2,7 @@
 BASE_URL = ''
 API_URL = ''
 LTI_CONSUMER_KEY = ''
-LTI_CONSUMER_SECRET = ''
+LTI_SHARED_SECRET = ''
 
 # generate a secret key with os.urandom(24)
 secret_key = ''
@@ -35,7 +35,7 @@ DATABASE_URIS = {
 PYLTI_CONFIG = {
     'consumers': {
         LTI_CONSUMER_KEY: {
-            "secret": LTI_CONSUMER_SECRET
+            "secret": LTI_SHARED_SECRET
         }
     },
     'roles': {


### PR DESCRIPTION
I had some trouble setting up this template since I wasn't sure where to add my LTI key and secret. This change introduces two new config variables which should make that more obvious.