### PR TITLE
Add support for OAUTH2 scoping and buff the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ import os
 os.urandom(24)
 ```
 
+##### Scope enforcement
+
+You may optionally enable scope enforcement when you create your developer key for Canvas. This means that people using keys derived from your developer key will only be able to access the endpoints which are listed in the enforcement list, which is good for security.
+
+To do this, turn on `Enforce Scopes` during the creation of your key. You can find the scopes you need beneath each API endpoint in the [Canvas API documentation](https://canvas.instructure.com/doc/api/index.html), listed after `Scope:`. The format listed is the exact format you'll need to use.
+
+The base template requires that `url:GET|/api/v1/users/:user_id/profile` is checked. Your use of the Canvas API may require more.
+
+Once you have enabled your desired scopes, place them in the configuration file in the list for `oauth2_scopes`, one per line.
+
 
 ### Create a DB
 - Modify the model as you see fit before creating the db! SQLAlchemy can make migrating a pain.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Join UCF Open Slack Discussions](https://ucf-open-slackin.herokuapp.com/badge.svg)](https://ucf-open-slackin.herokuapp.com/)
 
-# Python
-## Flask
+# LTI Template: Flask with OAUTH tokens
 
+## Set up a development server
 
 ### Virtual Environment
 - Create a virtual environment and install from requirements.txt.
@@ -13,24 +13,38 @@ source env/bin/activate
 pip install -r requirements.txt
 ```
 
-### Create settings.py from settings.py.template
-- Update the API url and key
-- Create the secret key, you can use the python shell:
+### Create developer key
 
-```
-import os
-os.urandom(24)
-```
+Before running the testing server, you will need to create an OAUTH key and secret. On an Instructure-hosted Canvas instance, enter your Account Admin page and click `Developer Keys`. Click `+ Developer Key` to create a new key.
 
-##### Scope enforcement
+In the dialog that appears, give your key a name and set the owner email to your own email address. Enter `https://[my_server_url]/oauthlogin` as a redirect URI. Click "Save Key" when you are satisfied with all of the fields.
+
+You will see your new key created in Canvas. Toggle its state from "Off" to "On" so your key is ready to use.
+
+
+#### Scope enforcement
 
 You may optionally enable scope enforcement when you create your developer key for Canvas. This means that people using keys derived from your developer key will only be able to access the endpoints which are listed in the enforcement list, which is good for security.
 
-To do this, turn on `Enforce Scopes` during the creation of your key. You can find the scopes you need beneath each API endpoint in the [Canvas API documentation](https://canvas.instructure.com/doc/api/index.html), listed after `Scope:`. The format listed is the exact format you'll need to use.
+To do this, turn on `Enforce Scopes` during the creation of your key. You can find the scopes you need beneath each API endpoint in the [Canvas API documentation](https://canvas.instructure.com/doc/api/index.html), listed after `Scope:`. The format listed is the exact format you'll need to use for our settings file later.
 
 The base template requires that `url:GET|/api/v1/users/:user_id/profile` is checked. Your use of the Canvas API may require more.
 
-Once you have enabled your desired scopes, place them in the configuration file in the list for `oauth2_scopes`, one per line.
+
+### Add server config
+
+Copy `settings.py.template` to `settings.py` in this project's directory. Open it to configure the following options:
+
+1. Set `BASE_URL` to the URL for your Canvas instance, for example `https://institution.instructure.com/`. Be sure to add the trailing slash!
+1. Set `API_URL` to the URL for the API of your Canvas instance. In most cases, this is the same as `BASE_URL`. Be sure to add the trailing slash!
+1. Set `LTI_CONSUMER_KEY` and `LTI_SHARED_SECRET` to any value you wish. Save this information for later, we'll use it while setting up the LTI.
+1. Enter a random string in the `secret_key` field. This secret key is used to sign session cookies to prevent an attacker from tampering with their contents.
+1. Set `oauth2_id` and `oauth2_key` to the ID and Key that Canvas gives you, respectively. The ID is shown under the "Details" column on the Developer Keys page. The key can be shown by clicking the "Show Key" button under the ID.
+1. Set `oauth2_uri` to the redirect URI you entered for the developer key earlier.
+
+You may also set `oauth2_scopes` if you wish. It takes a list of scope values, one for each API endpoint you will be using with the access tokens you gain. If you have scope enforcement enabled on your developer key, you **must** set `oauth2_scopes` to a list of endpoints less than or equal to those granted to your developer key.
+
+If you are using [canvasapi](https://github.com/ucfopen/canvasapi), the endpoint used for each call is listed in [its class reference documentation](https://canvasapi.readthedocs.io/en/latest/canvas-ref.html). You may click on the endpoint listing to learn the `Scope:` value for the endpoint.
 
 
 ### Create a DB
@@ -54,7 +68,7 @@ export FLASK_APP=views.py
 flask run
 ```
 
-# Install LTI
+### Install LTI
 - Have the XML, consumer key, and secret ready.
     - You can use the [XML Config Builder](https://www.edu-apps.org/build_xml.html) to build XML.
 - Navigate to the course that you would like the LTI to be added to. Click Settings in the course navigation bar. Then, select the Apps tab. Near the tabs on the right side, click 'View App Configurations'. It should lead to a page that lists what LTIs are inside the course. Click the button near the tabs that reads '+ App'.

--- a/settings.py.template
+++ b/settings.py.template
@@ -17,10 +17,15 @@ LOG_BACKUP_COUNT = 1
 # $oauth2_id: The Client_ID Instructure gives you
 # $oauth2_key: The Secret Instructure gives you
 # $oauth2_uri: The "Oauth2 Redirect URI" you provided instructure.
+# $oauth2_scopes: The scopes to request for use by this application.
 
 oauth2_id = ""
 oauth2_key = ""
 oauth2_uri = ""
+oauth2_scopes = " ".join([
+    # Uncomment the following line and add your desired scopes to enable token scoping:
+    # "url:GET|/api/v1/users/:user_id/profile",
+])
 
 # config object settings
 configClass = 'config.DevelopmentConfig'

--- a/views.py
+++ b/views.py
@@ -259,6 +259,18 @@ def oauth_login(lti=lti):
             please contact support.'''
         return return_error(msg)
 
+    elif r.status_code == 422:
+        # https://github.com/instructure/canvas-lms/issues/1343
+        app.logger.error(
+            "Status code 422 from oauth, are your oauth scopes valid?"
+        )
+
+        msg = '''Authentication error,
+            please refresh and try again. If this error persists,
+            please contact support.'''
+        return return_error(msg)
+
+
     if 'access_token' in r.json():
         session['api_key'] = r.json()['access_token']
 

--- a/views.py
+++ b/views.py
@@ -55,6 +55,19 @@ def error(exception=None):
         please contact support.''')
 
 
+def redirect_to_auth():
+    """Redirects the user to the Canvas OAUTH flow
+
+    This function uses BASE_URL and the oauth settings from settings.py to redirect the
+    user to the appropriate place in their Canvas installation for authentication.
+    """
+    return redirect(
+        "{}login/oauth2/auth?client_id={}&response_type=code&redirect_uri={}&scope={}".format(
+            settings.BASE_URL, settings.oauth2_id, settings.oauth2_uri, settings.oauth2_scopes
+        )
+    )
+
+
 def check_valid_user(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
@@ -344,13 +357,7 @@ def launch(lti=lti):
         app.logger.info(
             "Person doesn't have an entry in db, redirecting to oauth: {0}".format(session)
         )
-        return redirect(
-            '{}login/oauth2/auth?client_id={}&response_type=code&redirect_uri={}'.format(
-                settings.BASE_URL,
-                settings.oauth2_id,
-                settings.oauth2_uri
-            )
-        )
+        return redirect_to_auth()
 
     # Get the expiration date
     expiration_date = user.expires_in
@@ -380,13 +387,7 @@ def launch(lti=lti):
         else:
             # Refresh didn't work. Reauthenticate.
             app.logger.info('Reauthenticating:\nSession: {}'.format(session))
-            return redirect(
-                '{}login/oauth2/auth?client_id={}&response_type=code&redirect_uri={}'.format(
-                    settings.BASE_URL,
-                    settings.oauth2_id,
-                    settings.oauth2_uri
-                )
-            )
+            return redirect_to_auth()
     else:
         # Have an API key that shouldn't be expired. Test it to be sure.
         auth_header = {'Authorization': 'Bearer ' + session['api_key']}
@@ -417,13 +418,7 @@ def launch(lti=lti):
             else:
                 # Refresh didn't work. Reauthenticate.
                 app.logger.info('Reauthenticating:\nSession: {}'.format(session))
-                return redirect(
-                    '{}login/oauth2/auth?client_id={}&response_type=code&redirect_uri={}'.format(
-                        settings.BASE_URL,
-                        settings.oauth2_id,
-                        settings.oauth2_uri
-                    )
-                )
+                return redirect_to_auth()
 
 
 # XML


### PR DESCRIPTION
This PR adds the ability to scope the access tokens retrieved from the Canvas API. This allows developers to access only the information they need to do their job in their LTI.

I've also redone the README a bit to help people new to configuring these LTI's get started.