### PR TITLE
Do not put the refresh token in the session

### DIFF
--- a/views.py
+++ b/views.py
@@ -249,8 +249,7 @@ def oauth_login(lti=lti):
     if 'access_token' in r.json():
         session['api_key'] = r.json()['access_token']
 
-        if 'refresh_token' in r.json():
-            session['refresh_token'] = r.json()['refresh_token']
+        refresh_token = r.json()['refresh_token']
 
         if 'expires_in' in r.json():
             # expires in seconds
@@ -263,7 +262,7 @@ def oauth_login(lti=lti):
             user = Users.query.filter_by(user_id=int(session['canvas_user_id'])).first()
             if user is not None:
                 # update the current user's expiration time in db
-                user.refresh_key = session['refresh_token']
+                user.refresh_key = refresh_token
                 user.expires_in = session['expires_in']
                 db.session.add(user)
                 db.session.commit()
@@ -288,7 +287,7 @@ def oauth_login(lti=lti):
                 # add new user to db
                 new_user = Users(
                     session['canvas_user_id'],
-                    session['refresh_token'],
+                    refresh_token,
                     session['expires_in']
                 )
                 db.session.add(new_user)


### PR DESCRIPTION
The session storage by Flask is held as an unencrypted (but signed) cookie on the user's computer. This makes session storage a trustworthy but not confidential way to maintain state across an application. Storing secrets in plaintext on your user's computer (even if they're the user's secrets and not yours) is generally regarded as bad practice in my research. This PR starts to make the LTI template use the session less by taking the user's refresh token out of it. Now if an attacker gets hold of one of the template's cookies, they'll only have a maximum of one hour of access to the token owner's account.