### PR TITLE
Handle 404 errors from test API call

### DIFF
--- a/views.py
+++ b/views.py
@@ -397,7 +397,7 @@ def launch(lti=lti):
 
         # check for WWW-Authenticate
         # https://canvas.instructure.com/doc/api/file.oauth.html
-        if 'WWW-Authenticate' not in r.headers and r.status_code != 401:
+        if 'WWW-Authenticate' not in r.headers and r.status_code == 200:
             return redirect(url_for(
                 'index',
                 course_id=session['course_id'],


### PR DESCRIPTION
When checking if our OAUTH token is valid, we try to retrieve the
supposedly authenticated user's profile. If this fails with a 401
(unauthorized), we know that the token we have is invalid and we need a
new one.

In some configurations, the Canvas API won't return a 401 if our
credentials are invalid. Instead, it returns a 404. This is probably for
security reasons, it prevents unauthorized users from getting side
channel data about your users.

This change watches for all status codes which are not 200 from the
Canvas API. This means that we will redirect to authentication if the
Canvas API returns a 500,  which probably means that the server
is malfunctioning. I believe this is an acceptable risk since it is
unlikely that people will reach the LTI if the server is unable to
return their profile.